### PR TITLE
fix: Resolve AttributeError when generating log filename

### DIFF
--- a/src/pgmq/queue.py
+++ b/src/pgmq/queue.py
@@ -46,7 +46,7 @@ class PGMQueue:
         self.logger = logging.getLogger(__name__)
 
         if self.verbose:
-            log_filename = self.log_filename or datetime.now().strftime(
+            log_filename = self.log_filename or datetime.datetime.now().strftime(
                 "pgmq_debug_%Y%m%d_%H%M%S.log"
             )
             file_handler = logging.FileHandler(


### PR DESCRIPTION
This pull request fixes a bug that caused an AttributeError: module 'datetime' has no attribute 'now' when initializing logging in verbose mode.

The error occurred because the code was incorrectly calling datetime.now() instead of the correct datetime.datetime.now().

This change updates the method call to correctly reference the datetime class within the datetime module, ensuring that the timestamp for the log filename is generated without errors.