### PR TITLE
feat: Support callable kwargs for token callback authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgmq"
-version = "1.0.2"
+version = "1.0.3"
 description = "Python client for the PGMQ Postgres extension."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/pgmq/queue.py
+++ b/src/pgmq/queue.py
@@ -41,6 +41,10 @@ class PGMQueue:
         if callable(self.kwargs):
             self.pool = ConnectionPool(conninfo, open=True, kwargs=self.kwargs)
         else:
+            if "kwargs" in self.kwargs:
+                raise TypeError(
+                    "The 'kwargs' key is reserved for callables and cannot be used in the kwargs dictionary."
+                )
             self.pool = ConnectionPool(conninfo, open=True, **self.kwargs)
         self._initialize_logging()
         if self.init_extension:

--- a/uv.lock
+++ b/uv.lock
@@ -1428,7 +1428,7 @@ wheels = [
 
 [[package]]
 name = "pgmq"
-version = "1.0.1"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
### Summary
- Add support for callable `kwargs` parameter to enable token-based authentication with psycopg-pool v3.3.0+
- Bump version to 1.0.3

### Description

This PR adds support for the `kwargs` parameter to be a callable (function that returns a dict) in addition to a static dict. This enables integration with token-based authentication systems like AWS IAM, Azure AD, or GCP IAM where credentials need to be refreshed dynamically.

#### Background

In psycopg-pool v3.3.0, a new feature was introduced that allows the `kwargs` parameter to be a callable. When provided as a callable, it's invoked each time a new connection is created, allowing for dynamic credential refresh. This is essential for:

- **GCP Cloud SQL IAM Authentication** - Requires periodic token refresh

Should also work for:

- **AWS RDS IAM Authentication** - Tokens expire after 15 minutes
- **Azure AD Authentication** - OAuth tokens have limited lifetimes  
- **Any OAuth/OIDC based database authentication**

#### Changes

- Modified `PGMQueue.kwargs` type hint to accept `Union[dict, Callable[[], dict[str, Any]]]`
- Updated `__post_init__` to pass callable kwargs correctly to `ConnectionPool`

#### Usage Example

```python
import boto3

def get_auth_token():
    token = "XXXXX" # instead of XXXXX, fetch token 
    return {'password': token}

queue = PGMQueue(
    host='MY-DB-HOST',
    database='mydb',
    username='myuser',
    password='NOTUSED',  # Not used when using token auth
    kwargs= get_auth_token  # Callable that returns fresh credentials
)
```
