### PR TITLE
feat: add bring-your-own pool support for psycopg and asyncpg clients

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -25,6 +25,24 @@ queue = PGMQueue()
 queue.create_queue("my_queue")
 ```
 
+### Using an External Connection Pool
+
+You can provide your own `psycopg_pool.ConnectionPool` instead of letting the client create one. This is useful when you want to share a pool across multiple queue instances or with other parts of your application.
+
+```python
+from pgmq import PGMQueue
+from psycopg_pool import ConnectionPool
+
+pool = ConnectionPool("host=localhost dbname=postgres user=postgres", open=True)
+queue = PGMQueue(pool=pool)
+
+queue.create_queue("my_queue")
+
+# The queue will NOT close a user-provided pool on shutdown.
+# You are responsible for closing it yourself when appropriate.
+pool.close()
+```
+
 ## Async asyncpg Client
 
 Requires an explicit `await queue.init()` before use. Remember to `await queue.close()` on shutdown.
@@ -39,6 +57,27 @@ await queue.create_queue("my_queue")
 msg_id = await queue.send("my_queue", {"hello": "world"})
 
 await queue.close()
+```
+
+### Using an External Connection Pool
+
+You can inject an existing `asyncpg.Pool`. The queue will use it for all operations but will **not** close it when `queue.close()` is called.
+
+```python
+from pgmq import AsyncPGMQueue
+import asyncpg
+
+pool = await asyncpg.create_pool("postgresql://postgres:postgres@localhost/postgres")
+queue = AsyncPGMQueue(pool=pool)
+await queue.init()
+
+await queue.create_queue("my_queue")
+
+# queue.close() is safe — it will leave your external pool open.
+await queue.close()
+
+# Close the pool yourself when the application shuts down.
+await pool.close()
 ```
 
 ## Sync SQLAlchemy Client

--- a/src/pgmq/async_queue.py
+++ b/src/pgmq/async_queue.py
@@ -50,10 +50,6 @@ class AsyncpgBackend:
         """Initialize the asyncpg connection pool."""
         if self.pool is not None:
             if not self._own_pool:
-                if not isinstance(self.pool, Pool):
-                    raise TypeError(
-                        f"Expected asyncpg.Pool, got {type(self.pool).__name__}"
-                    )
                 log_with_context(
                     self.logger, logging.DEBUG, "Using user-provided connection pool"
                 )
@@ -78,7 +74,7 @@ class AsyncpgBackend:
 
     async def close(self) -> None:
         """Close the connection pool if it was created by this client."""
-        if self.pool:
+        if self.pool is not None:
             if self._own_pool:
                 await self.pool.close()
             self.pool = None
@@ -127,7 +123,7 @@ class PGMQueue(
     """
 
     pool: Optional[Pool] = None
-    _own_pool: bool = field(init=False, default=True)
+    _own_pool: bool = field(init=False, default=True, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         """Initialize configuration after dataclass construction."""

--- a/src/pgmq/async_queue.py
+++ b/src/pgmq/async_queue.py
@@ -48,6 +48,23 @@ class AsyncpgBackend:
 
     async def init(self) -> None:
         """Initialize the asyncpg connection pool."""
+        if self.pool is not None:
+            if not self._own_pool:
+                if not isinstance(self.pool, Pool):
+                    raise TypeError(
+                        f"Expected asyncpg.Pool, got {type(self.pool).__name__}"
+                    )
+                log_with_context(
+                    self.logger, logging.DEBUG, "Using user-provided connection pool"
+                )
+                if self.config.init_extension:
+                    async with self.pool.acquire() as conn:
+                        await conn.execute(
+                            "CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;"
+                        )
+            return
+
+        self._own_pool = True
         log_with_context(self.logger, logging.DEBUG, "Creating asyncpg pool")
         self.pool = await asyncpg.create_pool(
             self.config.async_dsn,
@@ -60,9 +77,10 @@ class AsyncpgBackend:
                 await conn.execute("CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;")
 
     async def close(self) -> None:
-        """Close the connection pool."""
+        """Close the connection pool if it was created by this client."""
         if self.pool:
-            await self.pool.close()
+            if self._own_pool:
+                await self.pool.close()
             self.pool = None
 
     async def _execute(
@@ -108,7 +126,8 @@ class PGMQueue(
     Asynchronous PGMQueue client for PostgreSQL Message Queue operations.
     """
 
-    pool: Optional[Pool] = field(init=False, default=None)
+    pool: Optional[Pool] = None
+    _own_pool: bool = field(init=False, default=True)
 
     def __post_init__(self) -> None:
         """Initialize configuration after dataclass construction."""
@@ -116,3 +135,5 @@ class PGMQueue(
             self,
             **{f.name: getattr(self, f.name) for f in fields(PGMQueueClientFields)},
         )
+        if self.pool is not None:
+            self._own_pool = False

--- a/src/pgmq/queue.py
+++ b/src/pgmq/queue.py
@@ -37,6 +37,18 @@ class PsycopgSyncBackend:
 
     def _init_pool(self) -> None:
         """Initialize the connection pool."""
+        if self.pool is not None:
+            if not self._own_pool:
+                if not isinstance(self.pool, ConnectionPool):
+                    raise TypeError(
+                        f"Expected psycopg_pool.ConnectionPool, got {type(self.pool).__name__}"
+                    )
+                log_with_context(
+                    self.logger, logging.DEBUG, "Using user-provided connection pool"
+                )
+            return
+
+        self._own_pool = True
         log_with_context(self.logger, logging.DEBUG, "Creating connection pool")
         self.pool = ConnectionPool(
             self.config.dsn,
@@ -44,6 +56,13 @@ class PsycopgSyncBackend:
             max_size=self.config.pool_size,
             open=True,
         )
+
+    def close(self) -> None:
+        """Close the connection pool if it was created by this client."""
+        if self.pool:
+            if self._own_pool:
+                self.pool.close()
+            self.pool = None
 
     def _init_extensions(self) -> None:
         """Ensure PGMQ extension is installed."""
@@ -87,7 +106,8 @@ class PGMQueue(
     Synchronous PGMQueue client for PostgreSQL Message Queue operations.
     """
 
-    pool: ConnectionPool = field(init=False, default=None)  # type: ignore
+    pool: Optional[ConnectionPool] = None
+    _own_pool: bool = field(init=False, default=True)
 
     def __post_init__(self):
         """Initialize connection pool after dataclass construction."""
@@ -95,6 +115,8 @@ class PGMQueue(
             self,
             **{f.name: getattr(self, f.name) for f in fields(PGMQueueClientFields)},
         )
+        if self.pool is not None:
+            self._own_pool = False
         self._init_pool()
         if self.config.init_extension:
             self._init_extensions()

--- a/src/pgmq/queue.py
+++ b/src/pgmq/queue.py
@@ -39,10 +39,6 @@ class PsycopgSyncBackend:
         """Initialize the connection pool."""
         if self.pool is not None:
             if not self._own_pool:
-                if not isinstance(self.pool, ConnectionPool):
-                    raise TypeError(
-                        f"Expected psycopg_pool.ConnectionPool, got {type(self.pool).__name__}"
-                    )
                 log_with_context(
                     self.logger, logging.DEBUG, "Using user-provided connection pool"
                 )
@@ -59,7 +55,7 @@ class PsycopgSyncBackend:
 
     def close(self) -> None:
         """Close the connection pool if it was created by this client."""
-        if self.pool:
+        if self.pool is not None:
             if self._own_pool:
                 self.pool.close()
             self.pool = None
@@ -107,7 +103,7 @@ class PGMQueue(
     """
 
     pool: Optional[ConnectionPool] = None
-    _own_pool: bool = field(init=False, default=True)
+    _own_pool: bool = field(init=False, default=True, repr=False, compare=False)
 
     def __post_init__(self):
         """Initialize connection pool after dataclass construction."""

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -2,6 +2,7 @@
 import unittest
 import asyncio
 import os
+import uuid
 from datetime import datetime, timezone, timedelta
 from unittest.mock import patch, AsyncMock
 
@@ -197,6 +198,48 @@ class TestAsyncQueue(unittest.IsolatedAsyncioTestCase):
             self.test_queue, qty=1, max_poll_seconds=1
         )
         self.assertIsInstance(msgs_poll, list)
+
+    async def test_external_pool(self):
+        """Test passing an external asyncpg pool to the queue."""
+        import asyncpg
+
+        dsn = (
+            f"postgresql://{PG_USERNAME}:{PG_PASSWORD}@"
+            f"{PG_HOST}:{PG_PORT}/{PG_DATABASE}"
+        )
+        pool = await asyncpg.create_pool(dsn)
+        try:
+            queue = AsyncPGMQueue(pool=pool, init_extension=False)
+            await queue.init()
+            self.assertIs(queue.pool, pool)
+            self.assertFalse(queue._own_pool)
+
+            test_queue = f"async_extpool_{uuid.uuid4().hex[:8]}"
+            await queue.create_queue(test_queue)
+            msg_id = await queue.send(test_queue, {"test": "external_pool"})
+            self.assertGreater(msg_id, 0)
+            await queue.drop_queue(test_queue)
+        finally:
+            await pool.close()
+
+    async def test_external_pool_not_closed_by_queue(self):
+        """Queue.close() should not close a user-provided pool."""
+        import asyncpg
+
+        dsn = (
+            f"postgresql://{PG_USERNAME}:{PG_PASSWORD}@"
+            f"{PG_HOST}:{PG_PORT}/{PG_DATABASE}"
+        )
+        pool = await asyncpg.create_pool(dsn)
+        queue = AsyncPGMQueue(pool=pool, init_extension=False)
+        await queue.init()
+        await queue.close()
+
+        async with pool.acquire() as conn:
+            result = await conn.fetchval("SELECT 1")
+            self.assertEqual(result, 1)
+
+        await pool.close()
 
 
 class TestAsyncInitNoExtension(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -76,6 +76,46 @@ class TestSyncQueue(PGMQTestCase):
         self.assertEqual(len(read_messages), 2)
         self.assertIsNone(self.queue.read(self.test_queue))
 
+    def test_external_pool(self):
+        """Test passing an external psycopg pool to the queue."""
+        from psycopg_pool import ConnectionPool
+
+        dsn = (
+            f"host={PG_HOST} port={PG_PORT} dbname={PG_DATABASE} "
+            f"user={PG_USERNAME} password={PG_PASSWORD}"
+        )
+        pool = ConnectionPool(dsn, open=True)
+        try:
+            queue = PGMQueue(pool=pool, init_extension=False)
+            self.assertIs(queue.pool, pool)
+            self.assertFalse(queue._own_pool)
+
+            test_queue = self.get_queue_name("extpool")
+            queue.create_queue(test_queue)
+            msg_id = queue.send(test_queue, {"test": "external_pool"})
+            self.assertGreater(msg_id, 0)
+            queue.drop_queue(test_queue)
+        finally:
+            pool.close()
+
+    def test_external_pool_not_closed_by_queue(self):
+        """Queue.close() should not close a user-provided pool."""
+        from psycopg_pool import ConnectionPool
+
+        dsn = (
+            f"host={PG_HOST} port={PG_PORT} dbname={PG_DATABASE} "
+            f"user={PG_USERNAME} password={PG_PASSWORD}"
+        )
+        pool = ConnectionPool(dsn, open=True)
+        queue = PGMQueue(pool=pool, init_extension=False)
+        queue.close()
+
+        with pool.connection() as conn:
+            result = conn.execute("SELECT 1").fetchone()
+            self.assertEqual(result[0], 1)
+
+        pool.close()
+
     def test_pop_message(self):
         msg_id = self.queue.send(self.test_queue, self.test_message)
         message = self.queue.pop(self.test_queue)


### PR DESCRIPTION
Allow users to inject an existing `psycopg_pool.ConnectionPool` or
asyncpg.Pool instead of having `PGMQueue` create one internally. This is
useful when sharing a pool across multiple queue instances or with other
parts of an application.

Track pool ownership with `_own_pool so close()` only shuts down pools
created by the client, leaving user-provided pools open. Reimplements
the refactored backend layout after #39; supersedes pgmq-py#35.

Closes pgmq/pgmq#318