### PR TITLE
ci: enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot version updates. Security alerts already run without this file.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+# https://docs.astral.sh/uv/guides/integration/dependabot/
+
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 8
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    groups:
+      runtime:
+        patterns:
+          - "orjson"
+          - "psycopg"
+          - "psycopg-*"
+          - "asyncpg"
+          - "sqlalchemy"
+      python-dev:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` so GitHub checks dependencies every Monday and opens PRs.
- `uv` ecosystem updates `pyproject.toml` / `uv.lock`. Runtime packages (`orjson`, `psycopg`, `asyncpg`, `sqlalchemy`) are grouped apart from dev/docs/bench extras.
- `github-actions` ecosystem updates Actions used in workflows.

This is not a custom workflow. Dependabot is GitHub's updater; the YAML is what turns on scheduled PRs. Security alerts already exist; this adds version updates.

Closes #44.

## Test plan

- [ ] After merge, confirm **Insights → Dependency graph → Dependabot** shows the `uv` and `github-actions` configs.
- [ ] First scheduled run (or **Check for updates**) should open PRs if anything is behind.